### PR TITLE
Fix OCR fallback without poppler

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,10 @@ python -m pdf2txt --input-folder ./input_pdfs --output-folder ./output_txts
 Options:
 
 - `--overwrite [skip|yes|append]` – control existing TXT files (default `skip`).
-- `--use-ocr` – enable OCR fallback for scanned PDFs.
+- `--use-ocr` – enable OCR fallback for scanned PDFs (requires Tesseract).
 - `--jobs N` – number of parallel workers (default `1`).
 
 The log file `conversion.log` is written inside the output folder.
+
+Note: OCR processing now renders pages with PyMuPDF, so Poppler is **not**
+required for image-based PDFs.

--- a/pdf2txt/ocr_fallback.py
+++ b/pdf2txt/ocr_fallback.py
@@ -1,14 +1,18 @@
 from pathlib import Path
-from pdf2image import convert_from_path
+from io import BytesIO
+
 from PIL import Image
 import pytesseract
+import fitz  # PyMuPDF
 
 
 def ocr_pdf_to_text(pdf_path: Path) -> str:
-    """Extract text from PDF using OCR."""
+    """Extract text from PDF using OCR without requiring Poppler."""
     text_chunks = []
-    images = convert_from_path(str(pdf_path))
-    for img in images:
-        text = pytesseract.image_to_string(img)
-        text_chunks.append(text)
+    with fitz.open(pdf_path) as doc:
+        for page in doc:
+            pix = page.get_pixmap()
+            image = Image.open(BytesIO(pix.tobytes("png")))
+            text = pytesseract.image_to_string(image)
+            text_chunks.append(text)
     return "\n".join(text_chunks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@ pdfminer.six>=20221105
 
 # OCR-Fallback 
 pytesseract>=0.3.10    
-pdf2image>=1.17.0      
 Pillow>=10.0.0         
 
 # CLI & UX


### PR DESCRIPTION
## Summary
- avoid poppler dependency by rendering PDF pages to images with PyMuPDF
- update requirements accordingly
- document that OCR now doesn't require poppler

## Testing
- `python -m pdf2txt --help`
- `python -m pdf2txt --input-folder input_pdfs --output-folder output_txts --use-ocr` *(fails: tesseract not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e9215196c83338edf77e097ad3db2