### PR TITLE
Add curl-based installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,21 @@ folders. The script accepts the following commands:
 that directory. If `--daemon` is supplied, a cron job is added to run the
 converter every five minutes. Use `--deinstall` to remove the installation and
 `--update` to pull the latest changes from git.
+
+### Quick Install via Curl
+
+For a one-liner installation that clones the repository and runs the setup
+script, use the provided `quick_install.sh` helper. This requires `git` and
+`sudo` to be available on the machine.
+
+```bash
+curl -sSL https://raw.githubusercontent.com/youruser/pdf2txtconvert/main/quick_install.sh | bash
+```
+
+Any arguments after the script URL are passed directly to `setup.sh`. For
+example, to install and enable daemon mode:
+
+```bash
+curl -sSL https://raw.githubusercontent.com/youruser/pdf2txtconvert/main/quick_install.sh | bash -s -- --daemon
+```
+

--- a/quick_install.sh
+++ b/quick_install.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Simple installer that clones the repository and runs setup.sh
+set -e
+
+REPO_URL="https://github.com/youruser/pdf2txtconvert.git"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cd "$TMP_DIR"
+
+echo "Cloning $REPO_URL"
+
+git clone --depth 1 "$REPO_URL" repo
+cd repo
+
+sudo ./setup.sh --install "$@"
+


### PR DESCRIPTION
## Summary
- add `quick_install.sh` helper script
- document curl installer usage in the README

## Testing
- `bash -n quick_install.sh`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684e96bc308483338f1affea25d2a38b