### PR TITLE
Fix formula extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ python -m pdf2txt --input-folder ./input_pdfs --output-folder ./output_txts
 
 The log file `conversion.log` is created in the output directory. OCR no longer needs Poppler because pages are rendered with PyMuPDF.
 
+### Handling mathematical formulas
+
+Extraction now preserves whitespace and ligatures so multi-line mathematical formulas and special characters survive conversion.
+
 ## setup.sh helper
 
 `setup.sh` installs the project to `/opt/pdf2txtconvert` with a virtual environment and fixed input/output folders.

--- a/pdf2txt/converter.py
+++ b/pdf2txt/converter.py
@@ -1,16 +1,24 @@
 from pathlib import Path
 from loguru import logger
 import fitz  # PyMuPDF
+
+# Flags to preserve layout and special characters
+MUPDF_FLAGS = (
+    fitz.TEXT_PRESERVE_WHITESPACE
+    | fitz.TEXT_PRESERVE_LIGATURES
+    | fitz.TEXT_INHIBIT_SPACES
+)
 from pdfminer.high_level import extract_text as pdfminer_extract
 
 from .ocr_fallback import ocr_pdf_to_text
 
 
 def extract_with_pymupdf(pdf_path: Path) -> str:
+    """Extract text from a PDF using PyMuPDF with layout preservation."""
     text = []
     with fitz.open(pdf_path) as doc:
         for page in doc:
-            text.append(page.get_text())
+            text.append(page.get_text("text", flags=MUPDF_FLAGS))
     return "\n".join(text)
 
 


### PR DESCRIPTION
## Summary
- preserve whitespace/ligatures in PyMuPDF extraction
- document handling of mathematical formulas in README

## Testing
- `python -m compileall -q`

------
https://chatgpt.com/codex/tasks/task_e_684e9f1ef2508333b77b4c16e22d18c8