### PR TITLE
Add LaTeX OCR option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ python -m pdf2txt --input-folder ./input_pdfs --output-folder ./output_txts
 
 - `--overwrite [skip|yes|append]` – what to do if the TXT already exists (default `skip`)
 - `--use-ocr` – enable OCR fallback for scanned PDFs
+- `--via-latex` – use LaTeX-OCR pipeline for better formula handling
 - `--jobs N` – number of parallel workers (default `1`)
 
 The log file `conversion.log` is created in the output directory. OCR no longer needs Poppler because pages are rendered with PyMuPDF.
@@ -41,6 +42,7 @@ The log file `conversion.log` is created in the output directory. OCR no longer 
 ### Handling mathematical formulas
 
 Extraction now preserves whitespace and ligatures so multi-line mathematical formulas and special characters survive conversion.
+When the optional `--via-latex` flag is used, pages are processed with [LaTeX-OCR](https://github.com/lukas-blecher/LaTeX-OCR) to generate LaTeX code first and then converted to plain text for improved table and formula handling.
 
 ## setup.sh helper
 

--- a/pdf2txt/__init__.py
+++ b/pdf2txt/__init__.py
@@ -1,4 +1,5 @@
-__all__ = ['scan_pdfs', 'convert_pdf_to_text']
+__all__ = ['scan_pdfs', 'convert_pdf_to_text', 'extract_with_latexocr']
 
 from .scanner import scan_pdfs
 from .converter import convert_pdf_to_text
+from .latex_converter import extract_with_latexocr

--- a/pdf2txt/cli.py
+++ b/pdf2txt/cli.py
@@ -15,8 +15,9 @@ from .logger_config import configure
 @click.option('--output-folder', required=True, type=click.Path(file_okay=False))
 @click.option('--overwrite', default='skip', type=click.Choice(['skip', 'yes', 'append']), show_default=True)
 @click.option('--use-ocr', is_flag=True, help='Enable OCR fallback for image-based PDFs')
+@click.option('--via-latex', is_flag=True, help='Use LaTeX-OCR pipeline')
 @click.option('--jobs', default=1, show_default=True, type=int, help='Number of parallel workers')
-def main(input_folder, output_folder, overwrite, use_ocr, jobs):
+def main(input_folder, output_folder, overwrite, use_ocr, via_latex, jobs):
     """Bulk convert PDF files to TXT."""
     output = Path(output_folder)
     output.mkdir(parents=True, exist_ok=True)
@@ -29,7 +30,13 @@ def main(input_folder, output_folder, overwrite, use_ocr, jobs):
 
     def process(pdf_path: Path):
         txt_path = output / f"{pdf_path.stem}.txt"
-        return convert_pdf_to_text(pdf_path, txt_path, overwrite=overwrite, use_ocr=use_ocr)
+        return convert_pdf_to_text(
+            pdf_path,
+            txt_path,
+            overwrite=overwrite,
+            use_ocr=use_ocr,
+            via_latex=via_latex,
+        )
 
     if jobs > 1:
         with ThreadPoolExecutor(max_workers=jobs) as executor:

--- a/pdf2txt/latex_converter.py
+++ b/pdf2txt/latex_converter.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+from io import BytesIO
+
+import fitz  # PyMuPDF
+from PIL import Image
+from loguru import logger
+from pylatexenc.latex2text import LatexNodes2Text
+
+try:
+    from pix2tex.cli import LatexOCR
+except Exception as e:  # ImportError or other
+    LatexOCR = None
+    _import_error = e
+else:
+    _import_error = None
+
+
+def extract_with_latexocr(pdf_path: Path) -> str:
+    """Extract text from a PDF using the LaTeX-OCR model."""
+    if LatexOCR is None:
+        raise ImportError(f"LatexOCR unavailable: {_import_error}")
+
+    ocr_model = LatexOCR()
+    converter = LatexNodes2Text()
+    text_chunks = []
+    with fitz.open(pdf_path) as doc:
+        for page in doc:
+            pix = page.get_pixmap()
+            image = Image.open(BytesIO(pix.tobytes("png")))
+            try:
+                latex = ocr_model(image)
+            except Exception as e:
+                logger.error(f"LatexOCR failed on page {page.number+1}: {e}")
+                latex = ""
+            text_chunks.append(converter.latex_to_text(latex))
+    return "\n".join(text_chunks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,12 @@ PyMuPDF>=1.24.3
 pdfminer.six>=20221105 
 
 # OCR-Fallback 
-pytesseract>=0.3.10    
-Pillow>=10.0.0         
+pytesseract>=0.3.10
+Pillow>=10.0.0
+
+# LaTeX OCR pipeline
+pylatexenc>=2.10
+git+https://github.com/lukas-blecher/LaTeX-OCR.git
 
 # CLI & UX
 click>=8.1.7           


### PR DESCRIPTION
## Summary
- add optional LaTeX-OCR pipeline for better formula extraction
- expose `extract_with_latexocr`
- support `--via-latex` flag in CLI
- document new option and install requirements

## Testing
- `python -m compileall -q pdf2txt`
- `pip check`
- `python -m pdf2txt --help`

------
https://chatgpt.com/codex/tasks/task_e_684ea2078bc88333a6cae7f02e482ae9