### PR TITLE
Fix spaces missing in PyMuPDF extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The log file `conversion.log` is created in the output directory. OCR no longer 
 
 ### Handling mathematical formulas
 
-Extraction now preserves whitespace and ligatures so multi-line mathematical formulas and special characters survive conversion.
+Extraction now preserves whitespace and ligatures so multi-line mathematical formulas and special characters survive conversion. The PyMuPDF extraction flags were adjusted to keep spaces even when PDFs lack explicit space characters.
 When the optional `--via-latex` flag is used, pages are processed with [LaTeX-OCR](https://github.com/lukas-blecher/LaTeX-OCR) to generate LaTeX code first and then converted to plain text for improved table and formula handling.
 Without the flag the first pages are scanned automatically and rerun through LaTeX-OCR whenever formulas are detected.
 

--- a/pdf2txt/converter.py
+++ b/pdf2txt/converter.py
@@ -6,7 +6,6 @@ import fitz  # PyMuPDF
 MUPDF_FLAGS = (
     fitz.TEXT_PRESERVE_WHITESPACE
     | fitz.TEXT_PRESERVE_LIGATURES
-    | fitz.TEXT_INHIBIT_SPACES
 )
 from pdfminer.high_level import extract_text as pdfminer_extract
 


### PR DESCRIPTION
## Summary
- ensure PyMuPDF inserts spaces by removing TEXT_INHIBIT_SPACES
- document updated behaviour in README

## Testing
- `python -m pdf2txt --help | head`
- `python -m pdf2txt --input-folder . --output-folder ./output_test --overwrite yes --jobs 1 > /tmp/run.log && tail -n 20 /tmp/run.log`

------
https://chatgpt.com/codex/tasks/task_e_684ea8fd7d6c8333b886af5f6a85172d