### PR TITLE
Handle zero-sized pages and add GPU install option

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Without the flag the first pages are scanned automatically and rerun through LaT
 `setup.sh` installs the project to `/opt/pdf2txtconvert` with a virtual environment and fixed input/output folders.
 
 ```
-./setup.sh --install [--daemon]
+./setup.sh --install [--daemon] [--gpu]
 ./setup.sh --deinstall
-./setup.sh --update
+./setup.sh --update [--gpu]
 ```
 
-Passing `--daemon` adds a cron entry to process PDFs every five minutes. Logs are stored alongside the installation.
+Use `--gpu` during install or update to set up PyTorch with CUDA support. Passing `--daemon` adds a cron entry to process PDFs every five minutes. Logs are stored alongside the installation.

--- a/pdf2txt/latex_converter.py
+++ b/pdf2txt/latex_converter.py
@@ -47,6 +47,12 @@ def extract_with_latexocr(
                 continue
             page = doc[pno]
             pix = page.get_pixmap()
+            if pix.width == 0 or pix.height == 0:
+                logger.warning(
+                    f"Skipping page {pno+1} for LaTeX-OCR: invalid size {pix.width}x{pix.height}"
+                )
+                results.append("")
+                continue
             image = Image.open(BytesIO(pix.tobytes("png")))
             try:
                 latex = ocr_model(image)

--- a/setup.sh
+++ b/setup.sh
@@ -7,9 +7,10 @@ INPUT_DIR="$INSTALL_DIR/input"
 OUTPUT_DIR="$INSTALL_DIR/output"
 VENV_DIR="$INSTALL_DIR/venv"
 RUN_SCRIPT="$INSTALL_DIR/run_converter.sh"
+GPU=0
 
 usage() {
-    echo "Usage: $0 [--install|--deinstall|--update] [--daemon]"
+    echo "Usage: $0 [--install|--deinstall|--update] [--daemon] [--gpu]"
     exit 1
 }
 
@@ -29,6 +30,9 @@ install() {
     source "$VENV_DIR/bin/activate"
     pip install --upgrade pip
     pip install -r "$INSTALL_DIR/requirements.txt"
+    if [ "$GPU" -eq 1 ]; then
+        pip install --extra-index-url https://download.pytorch.org/whl/cu118 torch torchvision torchaudio
+    fi
     deactivate
     mkdir -p "$INPUT_DIR" "$OUTPUT_DIR"
     cat <<EOS > "$RUN_SCRIPT"
@@ -52,6 +56,9 @@ update() {
         git -C "$INSTALL_DIR" pull
         source "$VENV_DIR/bin/activate"
         pip install -r "$INSTALL_DIR/requirements.txt"
+        if [ "$GPU" -eq 1 ]; then
+            pip install --extra-index-url https://download.pytorch.org/whl/cu118 torch torchvision torchaudio
+        fi
         deactivate
     else
         echo "No git repository found in $INSTALL_DIR"
@@ -66,6 +73,7 @@ while [ $# -gt 0 ]; do
         --deinstall) ACTION="deinstall" ; shift ;;
         --update) ACTION="update" ; shift ;;
         --daemon) DAEMON=1 ; shift ;;
+        --gpu) GPU=1 ; shift ;;
         *) usage ;;
     esac
 done


### PR DESCRIPTION
## Summary
- warn and skip invalid-sized pages in LaTeX OCR
- add `--gpu` option to setup script
- document GPU option in README

## Testing
- `python -m pdf2txt --help`

------
https://chatgpt.com/codex/tasks/task_e_684ead8fed408333976260579336f2b2